### PR TITLE
Initial experiment for backing up shuffle files.

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -35,6 +35,7 @@ import org.apache.spark.network.sasl.SecretKeyHolder;
 import org.apache.spark.network.server.NoOpRpcHandler;
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.shuffle.protocol.RegisterExecutor;
+import org.apache.spark.network.shuffle.protocol.RegisterExecutorForBackupsOnly;
 import org.apache.spark.network.util.TransportConf;
 
 /**
@@ -141,6 +142,19 @@ public class ExternalShuffleClient extends ShuffleClient {
     checkInit();
     try (TransportClient client = clientFactory.createUnmanagedClient(host, port)) {
       ByteBuffer registerMessage = new RegisterExecutor(appId, execId, executorInfo).toByteBuffer();
+      client.sendRpcSync(registerMessage, registrationTimeoutMs);
+    }
+  }
+
+  public void registerWithShuffleServerForBackups(
+      String host,
+      int port,
+      String execId,
+      String shuffleManager) throws IOException, InterruptedException{
+    checkInit();
+    try (TransportClient client = clientFactory.createUnmanagedClient(host, port)) {
+      ByteBuffer registerMessage = new RegisterExecutorForBackupsOnly(
+          appId, execId, shuffleManager).toByteBuffer();
       client.sendRpcSync(registerMessage, registrationTimeoutMs);
     }
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -91,6 +91,7 @@ public class ExternalShuffleClient extends ShuffleClient {
       int port,
       String execId,
       String[] blockIds,
+      boolean isBackup,
       BlockFetchingListener listener,
       DownloadFileManager downloadFileManager) {
     checkInit();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/FileWriterStreamCallback.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/FileWriterStreamCallback.java
@@ -1,0 +1,149 @@
+package org.apache.spark.network.shuffle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+
+import org.apache.spark.network.client.StreamCallbackWithID;
+
+final class FileWriterStreamCallback implements StreamCallbackWithID {
+
+  private static final Logger logger = LoggerFactory.getLogger(FileWriterStreamCallback.class);
+
+  public enum BackupFileType {
+    DATA("shuffle-data"),
+    INDEX("shuffle-index");
+
+    private final String typeString;
+
+    BackupFileType(String typeString) {
+      this.typeString = typeString;
+    }
+
+    @Override
+    public String toString() {
+      return typeString;
+    }
+  }
+  private final ExternalShuffleBlockResolver.AppExecId fullExecId;
+  private final int shuffleId;
+  private final int mapId;
+  private final File file;
+  private final BackupFileType fileType;
+  private WritableByteChannel fileOutputChannel = null;
+
+  FileWriterStreamCallback(
+      ExternalShuffleBlockResolver.AppExecId fullExecId,
+      int shuffleId,
+      int mapId,
+      File file,
+      BackupFileType fileType) {
+    this.fullExecId = fullExecId;
+    this.shuffleId = shuffleId;
+    this.mapId = mapId;
+    this.file = file;
+    this.fileType = fileType;
+  }
+
+  public void open() {
+    logger.info(
+        "Opening {} for backup writing. File type: {}", file.getAbsolutePath(), fileType);
+    if (fileOutputChannel != null) {
+      throw new IllegalStateException(
+          String.format(
+              "File %s for is already open for writing (type: %s).",
+              file.getAbsolutePath(),
+              fileType));
+    }
+    if (!file.exists()) {
+      try {
+        if (!file.getParentFile().isDirectory() && !file.getParentFile().mkdirs()) {
+          throw new IOException(
+              String.format(
+                  "Failed to create shuffle file directory at"
+                      + file.getParentFile().getAbsolutePath() + "(type: %s).", fileType));
+        }
+
+        if (!file.createNewFile()) {
+          throw new IOException(
+              String.format(
+                  "Failed to create shuffle file (type: %s).", fileType));
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(
+            String.format(
+                "Failed to create shuffle file at %s for backup (type: %s).",
+                file.getAbsolutePath(),
+                fileType),
+            e);
+      }
+    }
+    try {
+      // TODO encryption
+      fileOutputChannel = Channels.newChannel(new FileOutputStream(file));
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException(
+          String.format(
+              "Failed to find file for writing at %s (type: %s).",
+              file.getAbsolutePath(),
+              fileType),
+          e);
+    }
+  }
+
+  @Override
+  public String getID() {
+    return String.format("%s-%s-%d-%d-%s",
+        fullExecId.appId,
+        fullExecId.execId,
+        shuffleId,
+        mapId,
+        fileType);
+  }
+
+  @Override
+  public void onData(String streamId, ByteBuffer buf) throws IOException {
+    verifyShuffleFileOpenForWriting();
+    while (buf.hasRemaining()) {
+      fileOutputChannel.write(buf);
+    }
+  }
+
+  @Override
+  public void onComplete(String streamId) throws IOException {
+    fileOutputChannel.close();
+  }
+
+  @Override
+  public void onFailure(String streamId, Throwable cause) throws IOException {
+    logger.warn("Failed to back up shuffle file at {} (type: %s).",
+        file.getAbsolutePath(),
+        fileType,
+        cause);
+    fileOutputChannel.close();
+    // TODO delete parent dirs too
+    if (!file.delete()) {
+      logger.warn(
+          "Failed to delete incomplete backup shuffle file at %s (type: %s)",
+          file.getAbsolutePath(),
+          fileType);
+    }
+  }
+
+  private void verifyShuffleFileOpenForWriting() {
+    if (fileOutputChannel == null) {
+      throw new RuntimeException(
+          String.format(
+              "Shuffle file at %s not open for writing (type: %s).",
+              file.getAbsolutePath(),
+              fileType));
+    }
+  }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleClient.java
@@ -53,6 +53,7 @@ public abstract class ShuffleClient implements Closeable {
       int port,
       String execId,
       String[] blockIds,
+      boolean isBackup,
       BlockFetchingListener listener,
       DownloadFileManager downloadFileManager);
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
@@ -42,7 +42,8 @@ public abstract class BlockTransferMessage implements Encodable {
   /** Preceding every serialized message is its type, which allows us to deserialize it. */
   public enum Type {
     OPEN_BLOCKS(0), UPLOAD_BLOCK(1), REGISTER_EXECUTOR(2), STREAM_HANDLE(3), REGISTER_DRIVER(4),
-    HEARTBEAT(5), UPLOAD_BLOCK_STREAM(6);
+    HEARTBEAT(5), UPLOAD_BLOCK_STREAM(6), UPLOAD_SHUFFLE_FILE_STREAM(7), UPLOAD_SHUFFLE_INDEX_STREAM(8),
+    REGISTER_EXECUTOR_FOR_BACKUPS(9);
 
     private final byte id;
 
@@ -68,6 +69,9 @@ public abstract class BlockTransferMessage implements Encodable {
         case 4: return RegisterDriver.decode(buf);
         case 5: return ShuffleServiceHeartbeat.decode(buf);
         case 6: return UploadBlockStream.decode(buf);
+        case 7: return UploadShuffleFileStream.decode(buf);
+        case 8: return UploadShuffleIndexFileStream.decode(buf);
+        case 9: return RegisterExecutorForBackupsOnly.decode(buf);
         default: throw new IllegalArgumentException("Unknown message type: " + type);
       }
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RegisterExecutorForBackupsOnly.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RegisterExecutorForBackupsOnly.java
@@ -1,0 +1,71 @@
+package org.apache.spark.network.shuffle.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+
+import org.apache.spark.network.protocol.Encoders;
+
+public class RegisterExecutorForBackupsOnly extends BlockTransferMessage {
+
+  public final String appId;
+  public final String execId;
+  public final String shuffleManager;
+
+  public RegisterExecutorForBackupsOnly(
+      String appId, String execId, String shuffleManager) {
+    this.appId = appId;
+    this.execId = execId;
+    this.shuffleManager = shuffleManager;
+  }
+
+  @Override
+  protected Type type() {
+    return Type.REGISTER_EXECUTOR_FOR_BACKUPS;
+  }
+
+  @Override
+  public int encodedLength() {
+    return Encoders.Strings.encodedLength(appId)
+        + Encoders.Strings.encodedLength(execId)
+        + Encoders.Strings.encodedLength(shuffleManager);
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, appId);
+    Encoders.Strings.encode(buf, execId);
+    Encoders.Strings.encode(buf, shuffleManager);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof RegisterExecutorForBackupsOnly) {
+      RegisterExecutorForBackupsOnly o = (RegisterExecutorForBackupsOnly) other;
+      return Objects.equal(appId, o.appId)
+          && Objects.equal(execId, o.execId)
+          && Objects.equal(shuffleManager, o.shuffleManager);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(appId, execId, shuffleManager);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(RegisterExecutorForBackupsOnly.class)
+        .add("appId", appId)
+        .add("execId", execId)
+        .add("shuffleManager", shuffleManager)
+        .toString();
+  }
+
+  public static RegisterExecutorForBackupsOnly decode(ByteBuf buf) {
+    String appId = Encoders.Strings.decode(buf);
+    String execId = Encoders.Strings.decode(buf);
+    String shuffleManager = Encoders.Strings.decode(buf);
+    return new RegisterExecutorForBackupsOnly(appId, execId, shuffleManager);
+  }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/UploadShuffleFileStream.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/UploadShuffleFileStream.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+
+import org.apache.spark.network.protocol.Encoders;
+
+public class UploadShuffleFileStream extends BlockTransferMessage {
+  public final String appId;
+  public final String execId;
+  public final int shuffleId;
+  public final int mapId;
+
+  public UploadShuffleFileStream(
+      String appId,
+      String execId,
+      int shuffleId,
+      int mapId) {
+    this.appId = appId;
+    this.execId = execId;
+    this.shuffleId = shuffleId;
+    this.mapId = mapId;
+  }
+
+  @Override
+  protected Type type() {
+    return Type.UPLOAD_SHUFFLE_FILE_STREAM;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        appId,
+        execId,
+        shuffleId,
+        mapId);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("appId", appId)
+        .add("execId", execId)
+        .add("shuffleId", shuffleId)
+        .add("mapId", mapId)
+        .toString();
+  }
+
+  @Override
+  public int encodedLength() {
+    return Encoders.Strings.encodedLength(appId)
+        + Encoders.Strings.encodedLength(execId)
+        + 8;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, appId);
+    Encoders.Strings.encode(buf, execId);
+    buf.writeInt(shuffleId);
+    buf.writeInt(mapId);
+  }
+
+  public static UploadShuffleFileStream decode(ByteBuf buf) {
+    String appId = Encoders.Strings.decode(buf);
+    String execId = Encoders.Strings.decode(buf);
+    int shuffleId = buf.readInt();
+    int mapId = buf.readInt();
+    return new UploadShuffleFileStream(appId, execId, shuffleId, mapId);
+  }
+}

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/UploadShuffleIndexFileStream.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/UploadShuffleIndexFileStream.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+
+import org.apache.spark.network.protocol.Encoders;
+
+public class UploadShuffleIndexFileStream extends BlockTransferMessage {
+  public final String appId;
+  public final String execId;
+  public final int shuffleId;
+  public final int mapId;
+
+  public UploadShuffleIndexFileStream(
+      String appId,
+      String execId,
+      int shuffleId,
+      int mapId) {
+    this.appId = appId;
+    this.execId = execId;
+    this.shuffleId = shuffleId;
+    this.mapId = mapId;
+  }
+
+  @Override
+  protected Type type() {
+    return Type.UPLOAD_SHUFFLE_INDEX_STREAM;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        appId,
+        execId,
+        shuffleId,
+        mapId);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("appId", appId)
+        .add("execId", execId)
+        .add("shuffleId", shuffleId)
+        .add("mapId", mapId)
+        .toString();
+  }
+
+  @Override
+  public int encodedLength() {
+    return Encoders.Strings.encodedLength(appId)
+        + Encoders.Strings.encodedLength(execId)
+        + 8;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, appId);
+    Encoders.Strings.encode(buf, execId);
+    buf.writeInt(shuffleId);
+    buf.writeInt(mapId);
+  }
+
+  public static UploadShuffleIndexFileStream decode(ByteBuf buf) {
+    String appId = Encoders.Strings.decode(buf);
+    String execId = Encoders.Strings.decode(buf);
+    int shuffleId = buf.readInt();
+    int mapId = buf.readInt();
+    return new UploadShuffleIndexFileStream(appId, execId, shuffleId, mapId);
+  }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
@@ -135,7 +135,7 @@ public class ExternalShuffleIntegrationSuite {
 
     ExternalShuffleClient client = new ExternalShuffleClient(clientConf, null, false, 5000);
     client.init(APP_ID);
-    client.fetchBlocks(TestUtils.getLocalHost(), port, execId, blockIds,
+    client.fetchBlocks(TestUtils.getLocalHost(), port, execId, blockIds, false,
       new BlockFetchingListener() {
         @Override
         public void onBlockFetchSuccess(String blockId, ManagedBuffer data) {

--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -67,6 +67,7 @@ abstract class BlockTransferService extends ShuffleClient with Closeable with Lo
       port: Int,
       execId: String,
       blockIds: Array[String],
+      isBackup: Boolean,
       listener: BlockFetchingListener,
       tempFileManager: DownloadFileManager): Unit
 
@@ -92,10 +93,11 @@ abstract class BlockTransferService extends ShuffleClient with Closeable with Lo
       port: Int,
       execId: String,
       blockId: String,
+      isBackup: Boolean,
       tempFileManager: DownloadFileManager): ManagedBuffer = {
     // A monitor for the thread to wait on.
     val result = Promise[ManagedBuffer]()
-    fetchBlocks(host, port, execId, Array(blockId),
+    fetchBlocks(host, port, execId, Array(blockId), isBackup,
       new BlockFetchingListener {
         override def onBlockFetchFailure(blockId: String, exception: Throwable): Unit = {
           result.failure(exception)

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -105,6 +105,7 @@ private[spark] class NettyBlockTransferService(
       port: Int,
       execId: String,
       blockIds: Array[String],
+      isBackup: Boolean,
       listener: BlockFetchingListener,
       tempFileManager: DownloadFileManager): Unit = {
     logTrace(s"Fetch blocks from $host:$port (executor id $execId)")

--- a/core/src/main/scala/org/apache/spark/shuffle/BackingUpShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BackingUpShuffleWriter.scala
@@ -82,7 +82,7 @@ class BackingUpShuffleWriter[K, V](
         } yield {
           val backedUpMapStatus = RelocatedMapStatus(
             delegateMapStatus.get,
-            BlockManagerId(execId, backupHost, backupPort, None))
+            BlockManagerId(execId, backupHost, backupPort, None, isBackup = true))
           mapOutputTracker.trackerEndpoint.send(
               ReportBackedUpMapOutput(shuffleId, mapId, backedUpMapStatus))
         }

--- a/core/src/main/scala/org/apache/spark/shuffle/BackingUpShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BackingUpShuffleWriter.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.concurrent.ExecutorService
+
+import com.google.common.util.concurrent.SettableFuture
+import scala.concurrent.{ExecutionContext, Future}
+
+import org.apache.spark.{MapOutputTracker, ReportBackedUpMapOutput}
+import org.apache.spark.internal.Logging
+import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, NioManagedBuffer}
+import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
+import org.apache.spark.network.shuffle.protocol.{BlockTransferMessage, UploadShuffleFileStream, UploadShuffleIndexFileStream}
+import org.apache.spark.network.util.TransportConf
+import org.apache.spark.scheduler.{MapStatus, RelocatedMapStatus}
+import org.apache.spark.storage.BlockManagerId
+
+class BackingUpShuffleWriter[K, V](
+    shuffleBlockResolver: IndexShuffleBlockResolver,
+    delegateWriter: ShuffleWriter[K, V],
+    backupShuffleServiceClient: TransportClient,
+    transportConf: TransportConf,
+    mapOutputTracker: MapOutputTracker,
+    backupExecutor: ExecutorService,
+    backupHost: String,
+    backupPort: Int,
+    appId: String,
+    execId: String,
+    shuffleId: Int,
+    mapId: Int)
+  extends ShuffleWriter[K, V] with Logging {
+
+  private implicit val backupExecutorContext = ExecutionContext.fromExecutorService(backupExecutor)
+
+  /** Write a sequence of records to this task's output */
+  override def write(records: Iterator[Product2[K, V]]): Unit = {
+    delegateWriter.write(records)
+  }
+
+  /** Close this writer, passing along whether the map completed */
+  override def stop(success: Boolean): Option[MapStatus] = {
+    val delegateMapStatus = delegateWriter.stop(success)
+    delegateMapStatus.foreach { _ =>
+      val outputFile = shuffleBlockResolver.getDataFile(shuffleId, mapId)
+      val indexFile = shuffleBlockResolver.getIndexFile(shuffleId, mapId)
+      if (outputFile.isFile && indexFile.isFile) {
+        val uploadBackupFileRequest = new UploadShuffleFileStream(
+          appId, execId, shuffleId, mapId)
+        val uploadIndexFileRequest = new UploadShuffleIndexFileStream(
+          appId, execId, shuffleId, mapId)
+
+        val backupDataFileTask = Future {
+          backupFile(outputFile, uploadBackupFileRequest)
+        }
+
+        val backupIndexFileTask = Future {
+          backupFile(indexFile, uploadIndexFileRequest)
+        }
+
+        // TODO experiment with asynchronous backup.
+        for {
+          backupDataSuccess <- backupDataFileTask
+          backupIndexSuccess <- backupIndexFileTask
+        } yield {
+          val backedUpMapStatus = RelocatedMapStatus(
+            delegateMapStatus.get,
+            BlockManagerId(execId, backupHost, backupPort, None))
+          mapOutputTracker.trackerEndpoint.send(
+              ReportBackedUpMapOutput(shuffleId, mapId, backedUpMapStatus))
+        }
+      }
+    }
+    delegateMapStatus
+  }
+
+  private def backupFile(
+      fileToBackUp: File,
+      backupFileRequest: BlockTransferMessage) {
+    val dataFileBuffer = new FileSegmentManagedBuffer(
+      transportConf, fileToBackUp, 0, fileToBackUp.length())
+    val uploadBackupRequestBuffer = new NioManagedBuffer(backupFileRequest.toByteBuffer)
+    val awaitCompletion = SettableFuture.create[Boolean]
+    backupShuffleServiceClient.uploadStream(
+      uploadBackupRequestBuffer, dataFileBuffer, new RpcResponseCallback {
+
+        override def onSuccess(response: ByteBuffer): Unit = {
+          logInfo("Successfully backed up shuffle map data file" +
+            s" (shuffle id: $shuffleId, map id: $mapId, executor id: $execId)")
+          awaitCompletion.set(true)
+        }
+
+        /** Exception either propagated from server or raised on client side. */
+        override def onFailure(e: Throwable): Unit = {
+          logError("Failed to back up shuffle map data file" +
+            s" (shuffle id: $shuffleId, map id: $mapId, executor id: $execId)")
+          awaitCompletion.setException(e)
+        }
+      })
+    awaitCompletion.get()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -46,7 +46,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       context,
       blockManager.shuffleClient,
       blockManager,
-      mapOutputTracker.getMapSizesByExecutorId(handle.shuffleId, startPartition, endPartition),
+      mapOutputTracker.getMapSizesByExecutorId(
+        handle.shuffleId, startPartition, endPartition, context.attemptNumber()),
       serializerManager.wrapStream,
       // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
       SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024,

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -47,7 +47,7 @@ private[spark] class BlockStoreShuffleReader[K, C](
       blockManager.shuffleClient,
       blockManager,
       mapOutputTracker.getMapSizesByExecutorId(
-        handle.shuffleId, startPartition, endPartition, context.attemptNumber()),
+        handle.shuffleId, startPartition, endPartition, context.attemptNumber() > 0),
       serializerManager.wrapStream,
       // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
       SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024,

--- a/core/src/main/scala/org/apache/spark/shuffle/ExternalFallbackShuffleClient.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ExternalFallbackShuffleClient.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import java.net.URI
+
+import org.apache.spark.network.BlockTransferService
+import org.apache.spark.network.shuffle._
+
+private[spark] class ExternalFallbackShuffleClient(
+    shuffleServiceAddresses: Set[URI],
+    externalShuffleClient: ExternalShuffleClient,
+    baseBlockTransferService: BlockTransferService) extends ShuffleClient {
+
+  override def init(appId: String): Unit = {
+    externalShuffleClient.init(appId)
+    baseBlockTransferService.init(appId)
+  }
+
+  override def fetchBlocks(
+      host: String,
+      port: Int,
+      execId: String,
+      blockIds: Array[String],
+      listener: BlockFetchingListener,
+      downloadFileManager: DownloadFileManager): Unit = {
+    if (shuffleServiceAddresses.exists(
+      uri => uri.getHost.equals(host) && uri.getPort.equals(port))) {
+      externalShuffleClient.fetchBlocks(
+        host,
+        port,
+        execId,
+        blockIds,
+        listener,
+        downloadFileManager)
+    } else {
+      baseBlockTransferService.fetchBlocks(
+        host, port, execId, blockIds, listener, downloadFileManager)
+    }
+  }
+
+  override def close(): Unit = {
+    baseBlockTransferService.close()
+    externalShuffleClient.close()
+  }
+
+  def registerWithShuffleServerForBackups(
+      host: String,
+      port: Int,
+      execId: String,
+      shuffleManager: String) : Unit = {
+    externalShuffleClient.registerWithShuffleServerForBackups(host, port, execId, shuffleManager)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/ExternalFallbackShuffleClient.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ExternalFallbackShuffleClient.scala
@@ -17,13 +17,10 @@
 
 package org.apache.spark.shuffle
 
-import java.net.URI
-
 import org.apache.spark.network.BlockTransferService
 import org.apache.spark.network.shuffle._
 
 private[spark] class ExternalFallbackShuffleClient(
-    shuffleServiceAddresses: Set[URI],
     externalShuffleClient: ExternalShuffleClient,
     baseBlockTransferService: BlockTransferService) extends ShuffleClient {
 
@@ -37,20 +34,21 @@ private[spark] class ExternalFallbackShuffleClient(
       port: Int,
       execId: String,
       blockIds: Array[String],
+      isBackup: Boolean,
       listener: BlockFetchingListener,
       downloadFileManager: DownloadFileManager): Unit = {
-    if (shuffleServiceAddresses.exists(
-      uri => uri.getHost.equals(host) && uri.getPort.equals(port))) {
+    if (isBackup) {
       externalShuffleClient.fetchBlocks(
         host,
         port,
         execId,
         blockIds,
+        isBackup,
         listener,
         downloadFileManager)
     } else {
       baseBlockTransferService.fetchBlocks(
-        host, port, execId, blockIds, listener, downloadFileManager)
+        host, port, execId, blockIds, isBackup, listener, downloadFileManager)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -55,7 +55,7 @@ private[spark] class IndexShuffleBlockResolver(
     blockManager.diskBlockManager.getFile(ShuffleDataBlockId(shuffleId, mapId, NOOP_REDUCE_ID))
   }
 
-  private def getIndexFile(shuffleId: Int, mapId: Int): File = {
+  def getIndexFile(shuffleId: Int, mapId: Int): File = {
     blockManager.diskBlockManager.getFile(ShuffleIndexBlockId(shuffleId, mapId, NOOP_REDUCE_ID))
   }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleServiceAddressProvider.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleServiceAddressProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+trait ShuffleServiceAddressProvider {
+
+  def start(): Unit = {}
+
+  def getShuffleServiceAddresses(): List[(String, Int)]
+
+  def stop(): Unit = {}
+}
+
+private[spark] object DefaultShuffleServiceAddressProvider extends ShuffleServiceAddressProvider {
+  override def getShuffleServiceAddresses(): List[(String, Int)] = List.empty[(String, Int)]
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleServiceAddressProviderFactory.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleServiceAddressProviderFactory.scala
@@ -14,13 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.shuffle
 
-package org.apache.spark.storage
+import org.apache.spark.SparkConf
 
-import java.net.URI
+trait ShuffleServiceAddressProviderFactory {
+  def canCreate(masterUrl: String): Boolean
 
-trait BackupShuffleServiceAddressProvider {
-
-  def getBackupShuffleServiceAddresses(): Set[URI]
-
+  def create(conf: SparkConf): ShuffleServiceAddressProvider
 }

--- a/core/src/main/scala/org/apache/spark/storage/BackupShuffleServiceAddressProvider.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BackupShuffleServiceAddressProvider.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.net.URI
+
+trait BackupShuffleServiceAddressProvider {
+
+  def getBackupShuffleServiceAddresses(): Set[URI]
+
+}

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -254,11 +254,22 @@ final class ShuffleBlockFetcherIterator(
     // already encrypted and compressed over the wire(w.r.t. the related configs), we can just fetch
     // the data and write it to file directly.
     if (req.size > maxReqSizeShuffleToMem) {
-      shuffleClient.fetchBlocks(address.host, address.port, address.executorId, blockIds.toArray,
-        blockFetchingListener, this)
+      shuffleClient.fetchBlocks(
+          address.host,
+          address.port,
+          address.executorId,
+          blockIds.toArray,
+          address.isBackup,
+          blockFetchingListener, this)
     } else {
-      shuffleClient.fetchBlocks(address.host, address.port, address.executorId, blockIds.toArray,
-        blockFetchingListener, null)
+      shuffleClient.fetchBlocks(
+        address.host,
+        address.port,
+        address.executorId,
+        blockIds.toArray,
+        address.isBackup,
+        blockFetchingListener,
+        null)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/DistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/DistributedSuite.scala
@@ -189,8 +189,13 @@ class DistributedSuite extends SparkFunSuite with Matchers with LocalSparkContex
     assert(locations.size === storageLevel.replication,
       s"; got ${locations.size} replicas instead of ${storageLevel.replication}")
     locations.foreach { cmId =>
-      val bytes = blockTransfer.fetchBlockSync(cmId.host, cmId.port, cmId.executorId,
-        blockId.toString, null)
+      val bytes = blockTransfer.fetchBlockSync(
+        cmId.host,
+        cmId.port,
+        cmId.executorId,
+        blockId.toString,
+        cmId.isBackup,
+        null)
       val deserialized = serializerManager.dataDeserializeStream(blockId,
         new ChunkedByteBuffer(bytes.nioByteBuffer()).toInputStream())(data.elementClassTag).toList
       assert(deserialized === (1 to 100).toList)

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -313,7 +313,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
     tracker.registerMapOutput(10, 1, MapStatus(BlockManagerId("b", "hostB", 1000),
       Array(size10000, size0, size1000, size0)))
     assert(tracker.containsShuffle(10))
-    assert(tracker.getMapSizesByExecutorId(10, 0, 4).toSeq ===
+    assert(tracker.getMapSizesByExecutorId(10, 0, 4, 0).toSeq ===
         Seq(
           (BlockManagerId("a", "hostA", 1000),
               Seq((ShuffleBlockId(10, 0, 1), size1000), (ShuffleBlockId(10, 0, 3), size10000))),

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
@@ -156,7 +156,7 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
 
     val promise = Promise[ManagedBuffer]()
 
-    self.fetchBlocks(from.hostName, from.port, execId, Array(blockId.toString),
+    self.fetchBlocks(from.hostName, from.port, execId, Array(blockId.toString), false,
       new BlockFetchingListener {
         override def onBlockFetchFailure(blockId: String, exception: Throwable): Unit = {
           promise.failure(exception)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -24,7 +24,6 @@ import scala.annotation.meta.param
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Map}
 import scala.language.reflectiveCalls
 import scala.util.control.NonFatal
-
 import org.scalatest.concurrent.{Signaler, ThreadSignaler, TimeLimits}
 import org.scalatest.time.SpanSugar._
 
@@ -34,7 +33,7 @@ import org.apache.spark.executor.ExecutorMetrics
 import org.apache.spark.internal.config
 import org.apache.spark.rdd.{DeterministicLevel, RDD}
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
-import org.apache.spark.shuffle.{FetchFailedException, MetadataFetchFailedException}
+import org.apache.spark.shuffle.{DefaultShuffleServiceAddressProvider, FetchFailedException, MetadataFetchFailedException}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockManagerMaster}
 import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, CallSite, LongAccumulator, Utils}
 
@@ -250,7 +249,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     results.clear()
     securityMgr = new SecurityManager(conf)
     broadcastManager = new BroadcastManager(true, conf, securityMgr)
-    mapOutputTracker = new MapOutputTrackerMaster(conf, broadcastManager, true) {
+    mapOutputTracker = new MapOutputTrackerMaster(
+        conf, broadcastManager, true, DefaultShuffleServiceAddressProvider) {
       override def sendTracker(message: Any): Unit = {
         // no-op, just so we can stop this to avoid leaking threads
       }

--- a/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
@@ -102,7 +102,7 @@ class BlockStoreShuffleReaderSuite extends SparkFunSuite with LocalSparkContext 
     // shuffle data to read.
     val mapOutputTracker = mock(classOf[MapOutputTracker])
     when(mapOutputTracker.getMapSizesByExecutorId(
-        shuffleId, reduceId, reduceId + 1, 0)).thenReturn {
+        shuffleId, reduceId, reduceId + 1, false)).thenReturn {
       // Test a scenario where all data is local, to avoid creating a bunch of additional mocks
       // for the code to read data over the network.
       val shuffleBlockIdsAndSizes = (0 until numMaps).map { mapId =>

--- a/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
@@ -101,7 +101,8 @@ class BlockStoreShuffleReaderSuite extends SparkFunSuite with LocalSparkContext 
     // Make a mocked MapOutputTracker for the shuffle reader to use to determine what
     // shuffle data to read.
     val mapOutputTracker = mock(classOf[MapOutputTracker])
-    when(mapOutputTracker.getMapSizesByExecutorId(shuffleId, reduceId, reduceId + 1)).thenReturn {
+    when(mapOutputTracker.getMapSizesByExecutorId(
+        shuffleId, reduceId, reduceId + 1, 0)).thenReturn {
       // Test a scenario where all data is local, to avoid creating a bunch of additional mocks
       // for the code to read data over the network.
       val shuffleBlockIdsAndSizes = (0 until numMaps).map { mapId =>

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.language.postfixOps
-
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.concurrent.Eventually._
@@ -38,6 +37,7 @@ import org.apache.spark.network.netty.NettyBlockTransferService
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.serializer.{KryoSerializer, SerializerManager}
+import org.apache.spark.shuffle.DefaultShuffleServiceAddressProvider
 import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.storage.StorageLevel._
 import org.apache.spark.util.Utils
@@ -53,7 +53,8 @@ trait BlockManagerReplicationBehavior extends SparkFunSuite
   protected var master: BlockManagerMaster = null
   protected lazy val securityMgr = new SecurityManager(conf)
   protected lazy val bcastManager = new BroadcastManager(true, conf, securityMgr)
-  protected lazy val mapOutputTracker = new MapOutputTrackerMaster(conf, bcastManager, true)
+  protected lazy val mapOutputTracker = new MapOutputTrackerMaster(
+      conf, bcastManager, true, DefaultShuffleServiceAddressProvider)
   protected lazy val shuffleManager = new SortShuffleManager(conf)
 
   // List of block manager created during an unit test, so that all of the them can be stopped

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -46,7 +46,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
   /** Creates a mock [[BlockTransferService]] that returns data from the given map. */
   private def createMockTransfer(data: Map[BlockId, ManagedBuffer]): BlockTransferService = {
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = {
         val blocks = invocation.getArguments()(3).asInstanceOf[Array[String]]
@@ -140,7 +140,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     // 3 local blocks, and 2 remote blocks
     // (but from the same block manager so one call to fetchBlocks)
     verify(blockManager, times(3)).getBlockData(any())
-    verify(transfer, times(1)).fetchBlocks(any(), any(), any(), any(), any(), any())
+    verify(transfer, times(1)).fetchBlocks(any(), any(), any(), any(), any(), any(), any())
   }
 
   test("release current unexhausted buffer in case the task completes early") {
@@ -159,7 +159,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val sem = new Semaphore(0)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = {
         val listener = invocation.getArguments()(4).asInstanceOf[BlockFetchingListener]
@@ -227,7 +227,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val sem = new Semaphore(0)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = {
         val listener = invocation.getArguments()(4).asInstanceOf[BlockFetchingListener]
@@ -297,7 +297,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val corruptLocalBuffer = new FileSegmentManagedBuffer(null, new File("a"), 0, 100)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = {
         val listener = invocation.getArguments()(4).asInstanceOf[BlockFetchingListener]
@@ -337,7 +337,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val (id1, _) = iterator.next()
     assert(id1 === ShuffleBlockId(0, 0, 0))
 
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = {
         val listener = invocation.getArguments()(4).asInstanceOf[BlockFetchingListener]
@@ -415,7 +415,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val sem = new Semaphore(0)
 
     val transfer = mock(classOf[BlockTransferService])
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = {
         val listener = invocation.getArguments()(4).asInstanceOf[BlockFetchingListener]
@@ -479,7 +479,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       ShuffleBlockId(0, 0, 0) -> createMockManagedBuffer())
     val transfer = mock(classOf[BlockTransferService])
     var tempFileManager: DownloadFileManager = null
-    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any()))
+    when(transfer.fetchBlocks(any(), any(), any(), any(), any(), any(), any()))
       .thenAnswer(new Answer[Unit] {
         override def answer(invocation: InvocationOnMock): Unit = {
           val listener = invocation.getArguments()(4).asInstanceOf[BlockFetchingListener]

--- a/resource-managers/kubernetes/core/src/main/resources/META-INF/services/org.apache.spark.shuffle.ShuffleServiceAddressProviderFactory
+++ b/resource-managers/kubernetes/core/src/main/resources/META-INF/services/org.apache.spark.shuffle.ShuffleServiceAddressProviderFactory
@@ -1,0 +1,1 @@
+org.apache.spark.shuffle.k8s.KubernetesShuffleServiceAddressProviderFactory

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -241,6 +241,25 @@ private[spark] object Config extends Logging {
       .booleanConf
       .createWithDefault(false)
 
+  val KUBERNETES_BACKUP_SHUFFLE_SERVICE_ENABLED =
+    ConfigBuilder("spark.kubernetes.shuffle.service.backups.enabled")
+      .doc("Use shuffle service to back up shuffle data in Kubernetes applications.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val KUBERNETES_BACKUP_SHUFFLE_SERVICE_PODS_NAMESPACE =
+    ConfigBuilder("spark.kubernetes.shuffle.service.backups.pods.namespace")
+      .doc("Namespace of the pods that are running the shuffle service instances for backing up" +
+        " shuffle data.")
+      .stringConf
+      .createOptional
+
+  val KUBERNETES_BACKUP_SHUFFLE_SERVICE_PORT =
+    ConfigBuilder("spark.kubernetes.shuffle.service.backups.port")
+      .doc("Port of the shuffle services that will back up the application's shuffle data.")
+      .intConf
+      .createWithDefault(7337)
+
   val KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX =
     "spark.kubernetes.authenticate.submission"
 
@@ -269,4 +288,7 @@ private[spark] object Config extends Logging {
   val KUBERNETES_VOLUMES_OPTIONS_SIZE_LIMIT_KEY = "options.sizeLimit"
 
   val KUBERNETES_DRIVER_ENV_PREFIX = "spark.kubernetes.driverEnv."
+
+  val KUBERNETES_BACKUP_SHUFFLE_SERVICE_LABELS =
+      "spark.kubernetes.shuffle.service.backups.label."
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshot.scala
@@ -24,7 +24,7 @@ import org.apache.spark.internal.Logging
 /**
  * An immutable view of the current executor pods that are running in the cluster.
  */
-private[spark] case class ExecutorPodsSnapshot(executorPods: Map[Long, ExecutorPodState]) {
+private[spark] case class ExecutorPodsSnapshot(executorPods: Map[Long, SparkPodState]) {
 
   import ExecutorPodsSnapshot._
 
@@ -40,35 +40,11 @@ object ExecutorPodsSnapshot extends Logging {
     ExecutorPodsSnapshot(toStatesByExecutorId(executorPods))
   }
 
-  def apply(): ExecutorPodsSnapshot = ExecutorPodsSnapshot(Map.empty[Long, ExecutorPodState])
+  def apply(): ExecutorPodsSnapshot = ExecutorPodsSnapshot(Map.empty[Long, SparkPodState])
 
-  private def toStatesByExecutorId(executorPods: Seq[Pod]): Map[Long, ExecutorPodState] = {
+  private def toStatesByExecutorId(executorPods: Seq[Pod]): Map[Long, SparkPodState] = {
     executorPods.map { pod =>
-      (pod.getMetadata.getLabels.get(SPARK_EXECUTOR_ID_LABEL).toLong, toState(pod))
+      (pod.getMetadata.getLabels.get(SPARK_EXECUTOR_ID_LABEL).toLong, SparkPodState.toState(pod))
     }.toMap
   }
-
-  private def toState(pod: Pod): ExecutorPodState = {
-    if (isDeleted(pod)) {
-      PodDeleted(pod)
-    } else {
-      val phase = pod.getStatus.getPhase.toLowerCase
-      phase match {
-        case "pending" =>
-          PodPending(pod)
-        case "running" =>
-          PodRunning(pod)
-        case "failed" =>
-          PodFailed(pod)
-        case "succeeded" =>
-          PodSucceeded(pod)
-        case _ =>
-          logWarning(s"Received unknown phase $phase for executor pod with name" +
-            s" ${pod.getMetadata.getName} in namespace ${pod.getMetadata.getNamespace}")
-          PodUnknown(pod)
-      }
-    }
-  }
-
-  private def isDeleted(pod: Pod): Boolean = pod.getMetadata.getDeletionTimestamp != null
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProvider.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProvider.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle.k8s
+
+import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.{KubernetesClient, KubernetesClientException, Watch, Watcher}
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.cluster.k8s._
+import org.apache.spark.shuffle.ShuffleServiceAddressProvider
+import org.apache.spark.util.Utils
+
+class KubernetesShuffleServiceAddressProvider(
+    kubernetesClient: KubernetesClient,
+    pollForPodsExecutor: ScheduledExecutorService,
+    podLabels: Map[String, String],
+    namespace: String,
+    portNumber: Int)
+  extends ShuffleServiceAddressProvider with Logging {
+
+  // General implementation remark: this bears a strong resemblance to ExecutorPodsSnapshotsStore,
+  // but we don't need all "in-between" lists of all executor pods, just the latest known list
+  // when we query in getShuffleServiceAddresses.
+
+  private val podsUpdateLock = new ReentrantReadWriteLock()
+
+  private val shuffleServicePods = mutable.HashMap.empty[String, Pod]
+
+  private var shuffleServicePodsWatch: Watch = _
+  private var pollForPodsTask: ScheduledFuture[_] = _
+
+  override def start(): Unit = {
+    pollForPods()
+    pollForPodsTask = pollForPodsExecutor.scheduleWithFixedDelay(
+      () => pollForPods(), 0, 10, TimeUnit.SECONDS)
+    shuffleServicePodsWatch = kubernetesClient
+      .pods()
+      .inNamespace(namespace)
+      .withLabels(podLabels.asJava).watch(new PutPodsInCacheWatcher())
+  }
+
+  override def stop(): Unit = {
+    Utils.tryLogNonFatalError {
+      if (pollForPodsTask != null) {
+        pollForPodsTask.cancel(false)
+      }
+    }
+
+    Utils.tryLogNonFatalError {
+      if (shuffleServicePodsWatch != null) {
+        shuffleServicePodsWatch.close()
+      }
+    }
+
+    Utils.tryLogNonFatalError {
+      kubernetesClient.close()
+    }
+  }
+
+  override def getShuffleServiceAddresses(): List[(String, Int)] = {
+    val readLock = podsUpdateLock.readLock()
+    readLock.lock()
+    try {
+      val addresses = shuffleServicePods.values.map(pod => {
+        (pod.getStatus.getPodIP, portNumber)
+      }).toList
+      logInfo(s"Found backup shuffle service addresses at $addresses.")
+      addresses
+    } finally {
+      readLock.unlock()
+    }
+  }
+
+  private def pollForPods(): Unit = {
+    val writeLock = podsUpdateLock.writeLock()
+    writeLock.lock()
+    try {
+      val allPods = kubernetesClient
+        .pods()
+        .inNamespace(namespace)
+        .withLabels(podLabels.asJava)
+        .list()
+      shuffleServicePods.clear()
+      allPods.getItems.asScala.foreach(updatePod)
+    } finally {
+      writeLock.unlock()
+    }
+  }
+
+  private def updatePod(pod: Pod): Unit = {
+    require(podsUpdateLock.isWriteLockedByCurrentThread, "Should only update pods under lock.")
+    val state = SparkPodState.toState(pod)
+    state match {
+      case PodPending(_) | PodFailed(_) | PodSucceeded(_) | PodDeleted(_) =>
+        shuffleServicePods.remove(pod.getMetadata.getName)
+      case PodRunning(_) =>
+        shuffleServicePods.put(pod.getMetadata.getName, pod)
+      case _ =>
+        logWarning(s"Unknown state $state for pod named ${pod.getMetadata.getName}")
+    }
+  }
+
+  private def deletePod(pod: Pod): Unit = {
+    require(podsUpdateLock.isWriteLockedByCurrentThread, "Should only delete under lock.")
+    shuffleServicePods.remove(pod.getMetadata.getName)
+  }
+
+  private class PutPodsInCacheWatcher extends Watcher[Pod] {
+    override def eventReceived(action: Watcher.Action, pod: Pod): Unit = {
+      val writeLock = podsUpdateLock.writeLock()
+      writeLock.lock()
+      try {
+        updatePod(pod)
+      } finally {
+        writeLock.unlock()
+      }
+    }
+
+    override def onClose(e: KubernetesClientException): Unit = {}
+  }
+
+  private implicit def toRunnable(func: () => Unit): Runnable = {
+    new Runnable {
+      override def run(): Unit = func()
+    }
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProviderFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/shuffle/k8s/KubernetesShuffleServiceAddressProviderFactory.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle.k8s
+
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.SparkKubernetesClientFactory
+import org.apache.spark.shuffle.{DefaultShuffleServiceAddressProvider, ShuffleServiceAddressProvider, ShuffleServiceAddressProviderFactory}
+import org.apache.spark.util.ThreadUtils
+
+class KubernetesShuffleServiceAddressProviderFactory extends ShuffleServiceAddressProviderFactory {
+  override def canCreate(masterUrl: String): Boolean = masterUrl.startsWith("k8s://")
+
+  override def create(conf: SparkConf): ShuffleServiceAddressProvider = {
+    if (conf.get(KUBERNETES_BACKUP_SHUFFLE_SERVICE_ENABLED)) {
+      val kubernetesClient = SparkKubernetesClientFactory.getDriverKubernetesClient(
+        conf, conf.get("spark.master"))
+      val pollForPodsExecutor = ThreadUtils.newDaemonThreadPoolScheduledExecutor(
+          "poll-shuffle-service-pods", 1)
+      val shuffleServiceLabels = conf.getAllWithPrefix(KUBERNETES_BACKUP_SHUFFLE_SERVICE_LABELS)
+      val shuffleServicePodsNamespace = conf.get(KUBERNETES_BACKUP_SHUFFLE_SERVICE_PODS_NAMESPACE)
+      require(shuffleServicePodsNamespace.isDefined, "Namespace for the pods running the backup" +
+        s" shuffle service must be defined by" +
+        s" ${KUBERNETES_BACKUP_SHUFFLE_SERVICE_PODS_NAMESPACE.key}")
+      require(shuffleServiceLabels.nonEmpty, "Requires labels for the backup shuffle service pods.")
+
+      val port: Int = conf.get(KUBERNETES_BACKUP_SHUFFLE_SERVICE_PORT)
+      new KubernetesShuffleServiceAddressProvider(
+        kubernetesClient,
+        pollForPodsExecutor,
+        shuffleServiceLabels.toMap,
+        shuffleServicePodsNamespace.get,
+        port)
+    } else DefaultShuffleServiceAddressProvider
+  }
+}

--- a/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterManager.scala
+++ b/resource-managers/mesos/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterManager.scala
@@ -20,6 +20,8 @@ package org.apache.spark.scheduler.cluster.mesos
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.config._
 import org.apache.spark.scheduler.{ExternalClusterManager, SchedulerBackend, TaskScheduler, TaskSchedulerImpl}
+import org.apache.spark.scheduler.cluster.DefaultShuffleServiceAddressProvider
+import org.apache.spark.shuffle.{DefaultShuffleServiceAddressProvider, ShuffleServiceAddressProvider}
 
 /**
  * Cluster Manager for creation of Mesos scheduler and backend
@@ -60,5 +62,8 @@ private[spark] class MesosClusterManager extends ExternalClusterManager {
   override def initialize(scheduler: TaskScheduler, backend: SchedulerBackend): Unit = {
     scheduler.asInstanceOf[TaskSchedulerImpl].initialize(backend)
   }
+
+  override def createShuffleServiceAddressProvider(): ShuffleServiceAddressProvider =
+    DefaultShuffleServiceAddressProvider
 }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterManager.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterManager.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler.cluster
 
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.scheduler.{ExternalClusterManager, SchedulerBackend, TaskScheduler, TaskSchedulerImpl}
+import org.apache.spark.shuffle.{DefaultShuffleServiceAddressProvider, ShuffleServiceAddressProvider}
 
 /**
  * Cluster Manager for creation of Yarn scheduler and backend
@@ -53,4 +54,7 @@ private[spark] class YarnClusterManager extends ExternalClusterManager {
   override def initialize(scheduler: TaskScheduler, backend: SchedulerBackend): Unit = {
     scheduler.asInstanceOf[TaskSchedulerImpl].initialize(backend)
   }
+
+  override def createShuffleServiceAddressProvider(): ShuffleServiceAddressProvider =
+    DefaultShuffleServiceAddressProvider
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
@@ -24,7 +24,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.reflect.ClassTag
-
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.concurrent.Eventually._
@@ -39,6 +38,7 @@ import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.security.CryptoStreamUtils
 import org.apache.spark.serializer.{KryoSerializer, SerializerManager}
+import org.apache.spark.shuffle.DefaultShuffleServiceAddressProvider
 import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.storage._
 import org.apache.spark.streaming.receiver._
@@ -70,7 +70,8 @@ abstract class BaseReceivedBlockHandlerSuite(enableEncryption: Boolean)
   val streamId = 1
   val securityMgr = new SecurityManager(conf, encryptionKey)
   val broadcastManager = new BroadcastManager(true, conf, securityMgr)
-  val mapOutputTracker = new MapOutputTrackerMaster(conf, broadcastManager, true)
+  val mapOutputTracker = new MapOutputTrackerMaster(
+      conf, broadcastManager, true, None, DefaultShuffleServiceAddressProvider)
   val shuffleManager = new SortShuffleManager(conf)
   val serializer = new KryoSerializer(conf)
   var serializerManager = new SerializerManager(serializer, conf, encryptionKey)


### PR DESCRIPTION
Instead of expecting the shuffle service to just pick up the data written to local disk, executors can upload the data explicitly to the shuffle service. Shuffle services do not need to be colocated with executors this way.