### PR TITLE
[WIP] Api updates

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputChannelWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputChannelWriter.java
@@ -19,11 +19,9 @@ package org.apache.spark.shuffle.api;
 
 import java.io.IOException;
 
-public interface ShuffleMapOutputWriter {
+public interface ShuffleMapOutputChannelWriter extends ShuffleMapOutputWriter {
 
-  ShufflePartitionWriter newPartitionWriter(int partitionId);
+  @Override
+  ShufflePartitionChannelWriter newPartitionWriter(int partitionId);
 
-  void commitAllPartitions();
-
-  void abort(Exception exception) throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
@@ -23,7 +23,7 @@ public interface ShuffleMapOutputWriter {
 
   ShufflePartitionWriter newPartitionWriter(int partitionId);
 
-  void commitAllPartitions();
+  void commitAllPartitions(long[] lengths);
 
   void abort(Exception exception) throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionChannelWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionChannelWriter.java
@@ -14,16 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.shuffle.api;
 
 import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
 
-public interface ShuffleMapOutputWriter {
+/**
+ * An extension of ShufflePartitionWriter for shuffle storage implementations that allow transfering
+ * shuffle data directly to a WritableByteChannel, rather than an OutputStream.
+ *
+ * Callers may choose to use either the Channel or the OutputStream, but they must not mix usage of
+ * both.
+ */
+public interface ShufflePartitionChannelWriter extends ShufflePartitionWriter {
 
-  ShufflePartitionWriter newPartitionWriter(int partitionId);
-
-  void commitAllPartitions();
-
-  void abort(Exception exception) throws IOException;
+  /**
+   * Get a channel to write data to, to allow a more efficient transfer of data.
+   *
+   * Note that implementations are free to return the same channel for all ShufflePartitionWriters
+   * of one ShuffleMapOutputWriter.
+   */
+  WritableByteChannel openPartitionChannel() throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShufflePartitionWriter.java
@@ -17,24 +17,33 @@
 
 package org.apache.spark.shuffle.api;
 
-import java.io.InputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.WritableByteChannel;
 
 /**
- * Responsible for appending bytes to a partition via passing in input streams incrementally.
+ * Responsible for appending bytes to a partition via passing in input streams incrementally.  This
+ * corresponds to one (map, reduce) pair of partitions.
  */
 public interface ShufflePartitionWriter {
 
   /**
    * Return a stream that should persist the bytes for this partition.
+   *
+   * Note that implementations are free to return the same output stream for all
+   * ShufflePartitionWriters of one ShuffleMapOutputWriter.
    */
-  OutputStream openPartitionStream();
+  OutputStream openPartitionStream() throws IOException;
 
   /**
    * Indicate that the partition was written successfully and there are no more incoming bytes. Returns
    * the length of the partition that is written. Note that returning the length is mainly for backwards
    * compatibility and should be removed in a more polished variant. After this method is called, the writer
-   * will be discarded; it's expected that the implementation will close any underlying resources.
+   * will be discarded; it's expected that the implementation will close any underlying resources
+   * (unless the output stream / channel is reused for the entire ShuffleMapOutputWriter).
+   *
+   * TODO: Not sure this needs to return a length -- maybe should be called close()?
    */
   long commitAndGetTotalLength();
 

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleReadSupport.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleReadSupport.java
@@ -17,8 +17,15 @@
 
 package org.apache.spark.shuffle.api;
 
+import org.apache.spark.storage.BlockId;
+import scala.Tuple2;
+import scala.collection.Seq;
+
+import java.io.InputStream;
+import java.util.Iterator;
+
 public interface ShuffleReadSupport {
 
-  ShufflePartitionReader newPartitionReader(String appId, int shuffleId, int mapId);
+  Iterator<InputStream> fetchBlocks(String appId, int shuffleId, Iterator<Tuple2<Integer, Seq<BlockId>>> blocks);
 
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -267,7 +267,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
           }
         }
       }
-      mapOutputWriter.commitAllPartitions();
+      mapOutputWriter.commitAllPartitions(lengths);
     } catch (Exception e) {
       try {
         mapOutputWriter.abort(e);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/LocalShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/LocalShuffleMapOutputWriter.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle.sort;
+
+import org.apache.spark.network.util.JavaUtils;
+import org.apache.spark.shuffle.IndexShuffleBlockResolver;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.ShufflePartitionChannelWriter;
+import org.apache.spark.shuffle.api.ShufflePartitionWriter;
+
+import java.io.*;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Writes shuffle output from one shuffle map task to the local file system, with a separate
+ * index & data file.
+ *
+ * This corresponds to the only shuffle storage in spark <= 2.4.
+ */
+public class LocalShuffleMapOutputWriter implements ShuffleMapOutputWriter {
+
+  final IndexShuffleBlockResolver resolver;
+  final int shuffleId;
+  final int mapId;
+  long partitionLengths[];
+
+  File dataTmpFile;
+
+  FileChannel dataTmpFileOutputChannel = null;
+  FileOutputStream dataTmpFileOutputStream = null;
+
+  public LocalShuffleMapOutputWriter(IndexShuffleBlockResolver resolver, int shuffleId, int mapId) {
+    this.resolver = resolver;
+    this.shuffleId = shuffleId;
+    this.mapId = mapId;
+  }
+
+  @Override
+  public ShufflePartitionWriter newPartitionWriter(int partitionId) {
+    return null;
+  }
+
+  @Override
+  public void commitAllPartitions() {
+    // this will delete the temporary index file itself if there is a failure
+    resolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, dataTmpFile);
+  }
+
+  @Override
+  public void abort(Exception exception) throws IOException {
+    JavaUtils.closeQuietly(dataTmpFileOutputChannel);
+    JavaUtils.closeQuietly(dataTmpFileOutputStream);
+    if (dataTmpFile.exists() && !dataTmpFile.delete()) {
+      throw new IOException("failed to delete temporary shuffle output file " + dataTmpFile);
+    }
+  }
+
+  private class LocalShufflePartitionWriter implements ShufflePartitionChannelWriter {
+
+    @Override
+    public OutputStream openPartitionStream() throws FileNotFoundException {
+      if (dataTmpFileOutputStream == null) {
+        dataTmpFileOutputStream = new FileOutputStream(dataTmpFile);
+      }
+      return dataTmpFileOutputStream;
+    }
+
+    @Override
+    public WritableByteChannel openPartitionChannel() throws FileNotFoundException {
+      if (dataTmpFileOutputChannel == null) {
+        // This file needs to opened in append mode in order to work around a Linux kernel bug that
+        // affects transferTo; see SPARK-3948 for more details.
+        dataTmpFileOutputChannel = new FileOutputStream(dataTmpFile, true).getChannel();
+      }
+      return dataTmpFileOutputChannel;
+    }
+
+    @Override
+    public long commitAndGetTotalLength() {
+      // do NOT close any resources here, as we'll reuse them for other outputs
+      return 0;
+    }
+
+    @Override
+    public void abort(Exception failureReason) {
+      // don't need to to anything, it'll get handled by the wrapping LocalShuffleMapOutput
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockingShuffleReadSupport.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockingShuffleReadSupport.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle
+
+import java.io.InputStream
+import java.util.{Iterator => JIterator}
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.shuffle.api.{ShufflePartitionReader, ShuffleReadSupport}
+import org.apache.spark.storage.{BlockId, ShuffleBlockId, ShuffleDataBlockId}
+
+/**
+ * A very simple implementation of ShuffleReadSupport that fetches one block at a time, and doesn't
+ * even start requesting the next block until more data is requested
+ */
+abstract class BlockingShuffleReadSupport extends ShuffleReadSupport {
+  def newPartitionReader(appId: String, shuffleId: Int, mapId: Int): ShufflePartitionReader
+
+  override
+  def fetchBlocks(
+      appId: String,
+      shuffleId: Int,
+      blocks: JIterator[(Integer, Seq[BlockId])]): JIterator[InputStream] = {
+    blocks.asScala.flatMap { case (mapId, blockIds) =>
+      val reader = newPartitionReader(appId, shuffleId, mapId)
+      // TODO a custom iterator here which increments Shuffle fetch wait time, each time
+      // we end up waiting on a block.
+      blockIds.map {
+        case blockId@ShuffleBlockId(_, _, reduceId) =>
+          reader.fetchPartition(reduceId)
+        case dataBlockId@ShuffleDataBlockId(_, _, reduceId) =>
+          reader.fetchPartition(reduceId)
+        case invalid =>
+          throw new IllegalArgumentException(s"Invalid block id $invalid")
+      }
+    }.asJava
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -24,7 +24,7 @@ import java.lang.reflect.InvocationTargetException
 import java.math.{MathContext, RoundingMode}
 import java.net._
 import java.nio.ByteBuffer
-import java.nio.channels.{Channels, FileChannel}
+import java.nio.channels.{Channels, FileChannel, WritableByteChannel}
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.SecureRandom
@@ -298,12 +298,12 @@ private[spark] object Utils extends Logging {
       transferToEnabled: Boolean = false): Long = {
     tryWithSafeFinally {
       if (in.isInstanceOf[FileInputStream] && out.isInstanceOf[FileOutputStream]
-        && transferToEnabled) {
+          && transferToEnabled) {
         // When both streams are File stream, use transferTo to improve copy performance.
         val inChannel = in.asInstanceOf[FileInputStream].getChannel()
         val outChannel = out.asInstanceOf[FileOutputStream].getChannel()
         val size = inChannel.size()
-        copyFileStreamNIO(inChannel, outChannel, 0, size)
+        copyChannelsNIO(inChannel, outChannel, 0, size)
         size
       } else {
         var count = 0L
@@ -329,12 +329,15 @@ private[spark] object Utils extends Logging {
     }
   }
 
-  def copyFileStreamNIO(
+  def copyChannelsNIO(
       input: FileChannel,
-      output: FileChannel,
+      output: WritableByteChannel,
       startPosition: Long,
       bytesToCopy: Long): Unit = {
-    val initialPos = output.position()
+    val initialPos = output match {
+      case f: FileChannel => f.position()
+      case other => 0L
+    }
     var count = 0L
     // In case transferTo method transferred less data than we have required.
     while (count < bytesToCopy) {
@@ -342,22 +345,25 @@ private[spark] object Utils extends Logging {
     }
     assert(count == bytesToCopy,
       s"request to copy $bytesToCopy bytes, but actually copied $count bytes.")
-
-    // Check the position after transferTo loop to see if it is in the right position and
-    // give user information if not.
-    // Position will not be increased to the expected length after calling transferTo in
-    // kernel version 2.6.32, this issue can be seen in
-    // https://bugs.openjdk.java.net/browse/JDK-7052359
-    // This will lead to stream corruption issue when using sort-based shuffle (SPARK-3948).
-    val finalPos = output.position()
-    val expectedPos = initialPos + bytesToCopy
-    assert(finalPos == expectedPos,
-      s"""
-         |Current position $finalPos do not equal to expected position $expectedPos
-         |after transferTo, please check your kernel version to see if it is 2.6.32,
-         |this is a kernel bug which will lead to unexpected behavior when using transferTo.
-         |You can set spark.file.transferTo = false to disable this NIO feature.
+    output match {
+      case f: FileChannel =>
+        // Check the position after transferTo loop to see if it is in the right position and
+        // give user information if not.
+        // Position will not be increased to the expected length after calling transferTo in
+        // kernel version 2.6.32, this issue can be seen in
+        // https://bugs.openjdk.java.net/browse/JDK-7052359
+        // This will lead to stream corruption issue when using sort-based shuffle (SPARK-3948).
+        val finalPos = f.position()
+        val expectedPos = initialPos + bytesToCopy
+        assert(finalPos == expectedPos,
+          s"""
+             |Current position $finalPos do not equal to expected position $expectedPos
+             |after transferTo, please check your kernel version to see if it is 2.6.32,
+             |this is a kernel bug which will lead to unexpected behavior when using transferTo.
+             |You can set spark.file.transferTo = false to disable this NIO feature.
            """.stripMargin)
+    }
+
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -778,7 +778,7 @@ private[spark] class ExternalSorter[K, V, C](
           }
         }
       }
-      mapOutputWriter.commitAllPartitions()
+      mapOutputWriter.commitAllPartitions(lengths)
     } catch {
       case e: Exception =>
         util.Utils.tryLogNonFatalError {

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -694,7 +694,7 @@ public class UnsafeShuffleWriterSuite {
         }
 
         @Override
-        public void commitAllPartitions() {
+        public void commitAllPartitions(long[] partitionLengths) {
 
         }
 

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -49,7 +49,8 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
   private var taskMetrics: TaskMetrics = _
   private var tempDir: File = _
   private var outputFile: File = _
-  private val conf: SparkConf = new SparkConf(loadDefaults = false).set("spark.app.id", "spark-app-id")
+  private val conf: SparkConf =
+    new SparkConf(loadDefaults = false).set("spark.app.id", "spark-app-id")
   private val temporaryFilesCreated: mutable.Buffer[File] = new ArrayBuffer[File]()
   private val blockIdToFileMap: mutable.Map[BlockId, File] = new mutable.HashMap[BlockId, File]
   private var shuffleHandle: BypassMergeSortShuffleHandle[Int, Int] = _


### PR DESCRIPTION
Still a wip, but if its worth sharing already (no testing at all, but it does compile at least).

1) Add channels to shuffle write api, and move a *tiny bit* of the existing implementation behind that api. Just unsafeShuffleWriter#mergeWithTransferTo so far, but hopefully that demos the idea.

2) Make it possible for shuffle fetch pipelineing to occur, while still having a base class which makes it easy to implement without pipelining.  (Though I still want to look at ShuffleClient as perhaps an easier way to do this ...)

A lot of this is still ugly -- error handling hasn't been thought through, and scala ends up leaking into the api (it seems maybe you were trying to remove all scala from it?  though this code will all run within spark, so scala will be available anyway)