### PR TITLE
Adds hooks for custom fetch failure handling.

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockMetadata.java
@@ -17,8 +17,17 @@
 
 package org.apache.spark.shuffle.api.metadata;
 
+import java.io.Serializable;
+
 /**
  * Metadata tags returned from partition readers for each input stream to be read by
  * the reduce task.
  */
-public interface ShuffleBlockMetadata {}
+public interface ShuffleBlockMetadata extends Serializable {
+
+  /**
+   * Used for display in fetch failed exceptions.
+   */
+  String toPrintableString();
+
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
@@ -64,4 +64,44 @@ public interface ShuffleOutputTracker {
    * shuffle id.
    */
   Optional<ShuffleMetadata> getShuffleMetadata(int shuffleId);
+
+  /**
+   * Called when a shuffle reader implementation throws a fetch failure exception for the given
+   * shuffle block.
+   * <p>
+   * Implementations can choose to update internal state accordingly.
+   */
+  default void handleFetchFailure(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long mapTaskAttemptId,
+      Optional<ShuffleBlockMetadata> blockMetadata) {}
+
+  /**
+   * Called when an executor is lost.
+   * <p>
+   * Shuffle plugin implementations that store any state on the lost executor should update
+   * internal state accordingly.
+   */
+  default void handleExecutorLost(String executorId) {}
+
+  /**
+   * Called when a host running one or more executors is lost.
+   * <p>
+   * Shuffle plugin implementations that store any state on the lost host should update
+   * internal state accordingly.
+   */
+  default void handleHostLost(String host) {}
+
+  /**
+   * Inspect whether or not all partitions from the given map output are available in an external
+   * system, i.e. offloaded from an executor.
+   * <p>
+   * If the executor that ran the map task is lost, all map outputs that were written by that
+   * executor are checked against this method. For each map output that is not stored externally,
+   * that map output has to be recomputed.
+   */
+  boolean isMapOutputAvailableExternally(
+      int shuffleId, int mapId, long mapTaskAttemptId);
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleBlockMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleBlockMetadata.java
@@ -31,4 +31,9 @@ public class LocalDiskShuffleBlockMetadata implements ShuffleBlockMetadata {
   public BlockId getBlockId() {
     return blockId;
   }
+
+  @Override
+  public String toPrintableString() {
+    return blockId.toString();
+  }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.sort.io;
 import java.util.Optional;
 
 import org.apache.spark.shuffle.api.metadata.MapOutputMetadata;
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata;
 import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
 import org.apache.spark.shuffle.api.metadata.ShuffleOutputTracker;
 import org.apache.spark.storage.BlockManagerMaster;
@@ -50,5 +51,10 @@ public final class LocalDiskShuffleOutputTracker implements ShuffleOutputTracker
   @Override
   public Optional<ShuffleMetadata> getShuffleMetadata(int shuffleId) {
     return Optional.empty();
+  }
+
+  @Override
+  public boolean isMapOutputAvailableExternally(int shuffleId, int mapId, long mapTaskAttemptId) {
+    return false;
   }
 }

--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -22,6 +22,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.AccumulableInfo
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.{AccumulatorV2, Utils}
 
@@ -86,7 +87,8 @@ case class FetchFailed(
     mapId: Long,
     mapIndex: Int,
     reduceId: Int,
-    message: String)
+    message: String,
+    blockMetadata: Option[ShuffleBlockMetadata] = None)
   extends TaskFailedReason {
   override def toErrorString: String = {
     val bmAddressString = if (bmAddress == null) "null" else bmAddress.toString

--- a/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle
 
 import org.apache.spark.{FetchFailed, TaskContext, TaskFailedReason}
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.Utils
 
@@ -39,7 +40,8 @@ private[spark] class FetchFailedException(
     mapIndex: Int,
     reduceId: Int,
     message: String,
-    cause: Throwable = null)
+    cause: Throwable = null,
+    blockMetadata: Option[ShuffleBlockMetadata] = None)
   extends Exception(message, cause) {
 
   def this(
@@ -50,6 +52,18 @@ private[spark] class FetchFailedException(
       reduceId: Int,
       cause: Throwable) {
     this(bmAddress, shuffleId, mapTaskId, mapIndex, reduceId, cause.getMessage, cause)
+  }
+
+  def this(
+      bmAddress: BlockManagerId,
+      shuffleId: Int,
+      mapTaskId: Long,
+      mapIndex: Int,
+      reduceId: Int,
+      cause: Throwable,
+      blockMetadata: Option[ShuffleBlockMetadata]) {
+    this(
+      bmAddress, shuffleId, mapTaskId, mapIndex, reduceId, cause.getMessage, cause, blockMetadata)
   }
 
   // SPARK-19276. We set the fetch failure in the task context, so that even if there is user-code

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -2946,7 +2946,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       taskSets(2).tasks(0),
       FetchFailed(makeBlockManagerId("hostB"), shuffleId2, 0L, 0, 0, "ignored"),
       null))
-    mapOutputTracker.removeOutputsOnHost("hostB")
+    mapOutputTracker.removeOutputsByHost("hostB")
 
     assert(scheduler.failedStages.toSeq.map(_.id) == Seq(1, 2))
     scheduler.resubmitFailedStages()


### PR DESCRIPTION
Allows for avoiding map task recomputation if the plugin indicates that map outputs are persisted external to executors that are lost.