### PR TITLE
Create a hook for passing shuffle output metadata updates to the driver.

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleExecutorComponents.java
@@ -26,6 +26,7 @@ import org.apache.spark.annotation.Private;
 import org.apache.spark.shuffle.api.io.ShuffleBlockInputStream;
 import org.apache.spark.shuffle.api.metadata.ShuffleBlockInfo;
 import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
+import org.apache.spark.shuffle.api.metadata.ShuffleUpdater;
 
 /**
  * :: Private ::
@@ -44,8 +45,15 @@ public interface ShuffleExecutorComponents {
    * @param execId The unique identifier of the executor being initialized
    * @param extraConfigs Extra configs that were returned by
    *                     {@link ShuffleDriverComponents#initializeApplication()}
+   * @param updater A hook to the driver to send dynamic updates to shuffle storage information.
+   *                Only provided if {@link ShuffleDriverComponents#shuffleOutputTracker()} returns
+   *                a non-empty value (e.g. shuffle output tracking is enabled).
    */
-  void initializeExecutor(String appId, String execId, Map<String, String> extraConfigs);
+  void initializeExecutor(
+      String appId,
+      String execId,
+      Map<String, String> extraConfigs,
+      Optional<ShuffleUpdater> updater);
 
   /**
    * Called once per map task to create a writer that will be responsible for persisting all the

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
@@ -102,6 +102,12 @@ public interface ShuffleOutputTracker {
    * executor are checked against this method. For each map output that is not stored externally,
    * that map output has to be recomputed.
    */
-  boolean isMapOutputAvailableExternally(
-      int shuffleId, int mapId, long mapTaskAttemptId);
+  boolean isMapOutputAvailableExternally(int shuffleId, int mapId, long mapTaskAttemptId);
+
+  /**
+   * Send an update to this shuffle output tracker.
+   * <p>
+   * Executors can call
+   */
+  default void updateShuffleOutput(ShuffleOutputUpdate update) {}
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputUpdate.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputUpdate.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+import java.io.Serializable;
+
+/**
+ * Represents an opaque message to dynamically update information about the storage of shuffle
+ * data.
+ * <p>
+ * Executors are expected to send appropriate implementations of these to the driver via
+ * {@link ShuffleUpdater#updateShuffleOutput(ShuffleOutputUpdate)}, and the driver receives
+ * these updates in {@link ShuffleOutputTracker#updateShuffleOutput(ShuffleOutputUpdate)}.
+ */
+public interface ShuffleOutputUpdate extends Serializable {}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleUpdater.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleUpdater.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+/**
+ * Passed to {@link org.apache.spark.shuffle.api.ShuffleExecutorComponents} to allow for executors
+ * implementing the shuffle plugin tree to dynamically update shuffle storage metadata, sending
+ * appropriate updates to the driver.
+ */
+public interface ShuffleUpdater {
+
+  /**
+   * Sends an opaque update message to the driver.
+   * <p>
+   * This eventually delegates to
+   * {@link ShuffleOutputTracker#updateShuffleOutput(ShuffleOutputUpdate)} on the driver.
+   */
+  void updateShuffleOutput(ShuffleOutputUpdate update);
+}

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleExecutorComponents.java
@@ -36,6 +36,7 @@ import org.apache.spark.shuffle.api.SingleSpillShuffleMapOutputWriter;
 import org.apache.spark.shuffle.api.io.ShuffleBlockInputStream;
 import org.apache.spark.shuffle.api.metadata.ShuffleBlockInfo;
 import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
+import org.apache.spark.shuffle.api.metadata.ShuffleUpdater;
 import org.apache.spark.shuffle.sort.SortShuffleManager$;
 import org.apache.spark.storage.BlockManager;
 
@@ -63,7 +64,11 @@ public class LocalDiskShuffleExecutorComponents implements ShuffleExecutorCompon
   }
 
   @Override
-  public void initializeExecutor(String appId, String execId, Map<String, String> extraConfigs) {
+  public void initializeExecutor(
+      String appId,
+      String execId,
+      Map<String, String> extraConfigs,
+      Optional<ShuffleUpdater> updater) {
     blockManager = SparkEnv.get().blockManager();
     if (blockManager == null) {
       throw new IllegalStateException("No blockManager available from the SparkEnv.");

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -521,10 +521,12 @@ class SparkContext(config: SparkConf) extends Logging {
     _shuffleDriverComponents.initializeApplication().asScala.foreach { case (k, v) =>
       _conf.set(ShuffleDataIOUtils.SHUFFLE_SPARK_CONF_PREFIX + k, v)
     }
+    val shuffleOutputTracker = _shuffleDriverComponents.shuffleOutputTracker().asScala
     // Should really be done in SparkEnv creation, but initialization ordering is quite
     // difficult...
     env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].setShuffleOutputTracker(
-      _shuffleDriverComponents.shuffleOutputTracker().asScala)
+      shuffleOutputTracker)
+    _conf.set(SHUFFLE_IO_PLUGIN_OUTPUT_TRACKING_ENABLED, shuffleOutputTracker.isDefined)
 
     // We need to register "HeartbeatReceiver" before "createTaskScheduler" because Executor will
     // retrieve "HeartbeatReceiver" in the constructor. (SPARK-6640)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1096,6 +1096,15 @@ package object config {
       .stringConf
       .createWithDefault(classOf[LocalDiskShuffleDataIO].getName)
 
+  private[spark] val SHUFFLE_IO_PLUGIN_OUTPUT_TRACKING_ENABLED =
+    ConfigBuilder("spark.shuffle.sort.io.plugin.output.tracking.enabled")
+      .doc("Indicates whether or not the shuffle plugin has enabled custom output tracking." +
+        "Determined by the driver and sent to the executors; users should not set this manually.")
+      .version("3.1.0")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val SHUFFLE_FILE_BUFFER_SIZE =
     ConfigBuilder("spark.shuffle.file.buffer")
       .doc("Size of the in-memory buffer for each shuffle file output stream, in KiB unless " +


### PR DESCRIPTION
Allows the executors to pass updates to the shuffle output tracker via an RPC endpoint.